### PR TITLE
Fix correct highlight bug

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,7 +135,6 @@ body {
   width: 75px;
   height: 75px;
   border-radius: 50%;
-  background-color: #393E46;
   color: white;
   display: flex;
   justify-content: center;
@@ -211,7 +210,6 @@ body {
     width: 50px;
     height: 50px;
     border-radius: 50%;
-    background-color: #393E46;
     color: white;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Hard coded css rule from react legacy code was overriding tailwind css styles :D
Closes #11 